### PR TITLE
fix: switched to scheduling mass syncs instead of individual syncs

### DIFF
--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -24,7 +24,7 @@ jobs:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           region: ${{ secrets.AWS_REGION_NAME }}
-          version_label: AniMalSync-v-12
+          version_label: AniMalSync-v-13
           use_existing_version_if_available: true
           application_name: AniMalSync
           environment_name: Animalsync-env

--- a/lambda/sync/sync.py
+++ b/lambda/sync/sync.py
@@ -3,11 +3,15 @@ import time
 import boto3
 import os
 from botocore.exceptions import ClientError
+from boto3.dynamodb.conditions import Attr
 from utils.anilist import AnilistClient
 from utils.aws import get_dynamodb_user, log_sync, send_mal_authorization_email, update_dynamodb_user
 from utils.mal import MALClient
 from utils.exception import EmailNotVerifiedException, HTTPException, AniMalUserNotFoundException, MalUnauthorizedException
 from utils.logger import logger
+
+anilist = AnilistClient()
+mal = MALClient()
 
 def lambda_handler(event, _):
     """
@@ -21,121 +25,21 @@ def lambda_handler(event, _):
     """
     messages = event['Records']
 
-    anilist = AnilistClient()
-    mal = MALClient()
-    sfn = boto3.client('stepfunctions')
-
     failures = [] # Messages to redo
 
     for msg in messages:
         msg_contents = json.loads(json.loads(msg['body'])['Message'])
-        user_id = msg_contents['user_id']
-        executing_sfn_arn = msg_contents.get('sfn_exec_arn', None)
-        force = msg_contents.get('force', False)
-
         try:
-            user = get_dynamodb_user(
-                user_id=user_id,
-                fields=[
-                    'id', 'anilist_user_id', 'email', 'sent_mal_auth_email',
-                    'mal_access_token', 'mal_refresh_token', 'email_verified',
-                    'last_sync_timestamp', 'sync_sfn', 'sync_enabled'
-                ]
-            ) 
-
-            # Check that user can be synced
-            if user is None:
-                raise AniMalUserNotFoundException(user_id)
-
-            if not user['email_verified']:
-                raise EmailNotVerifiedException(user_id)
-
-            if 'mal_access_token' not in user or 'mal_refresh_token' not in user:
-                raise MalUnauthorizedException(user_id)
-
-            if 'sync_sfn' in user:
-                # If this is not a forced execution, check if there is another
-                # executing sfn arn that does not match this one. If there is,
-                # don't bother running this one. This will help with avoiding
-                # too many sfns for the same user.
-                if user['sync_sfn'] != executing_sfn_arn:
-                    if not force:
-                        logger.info(f"[User {user_id}] Already running SFN found. Stopping execution.")
-                        continue 
-                else:
-                    # If the saved sync sfn arn is the one that triggered this lambda,
-                    # then we can remove it since it's being handled now.
-                    update_dynamodb_user(
-                        user_id=user_id,
-                        data={
-                            'sync_sfn': None
-                        }
-                    )
-                    user['sync_sfn'] = None
-
-                    # I'm fairly certain this thing has a "fairly consistent" type of thing
-                    # going on. Depending on failure states and whatnot, we could have
-                    # currently running SFNs swap, but I think it's overall ok. Don't @ me though.
-
-            if not user['sync_enabled']: # Do not run script if user disabled sync
-                continue
-
-            media_entries = anilist.fetch_recently_updated_media(
-                user['anilist_user_id'], user.get('last_sync_timestamp', int(time.time()))
-            )[::-1]
-
-            # Iterate through entries and update on MAL
-            for entry in media_entries:
-                try:
-                    mal.update_media_list_entry(user, entry)
-                    logger.info(f"[User {user['id']}] ({entry['media']['type']}) Synced {AnilistClient.get_media_title(entry)}")
-                    log_sync(user, entry, True)
-                except MalUnauthorizedException:
-                    # If the user is not authorized on MAL, cease all further updates
-                    # and send authorization email
-                    try:
-                        send_mal_authorization_email(user=user)
-                        return
-                    except ClientError as e:
-                        # If sending authorization email failed, count this message as a failed message
-                        logger.error(f"[User {user['id']}] Could not trigger OAuth email lambda: {e}")
-                        raise e
-                except HTTPException as e:
-                    logger.error(f"[User {user['id']}] ({entry['media']['type']}) Failed to sync {AnilistClient.get_media_title(entry)}")
-                    log_sync(user, entry, False)
-
-            try:
-                # Update user's last sync time (assuming no mal authorization was needed)
-                update_dynamodb_user(
-                    user_id=user_id,
-                    data={
-                        'last_sync_timestamp': int(time.time())
-                    }
-                )
-            except ClientError as e:
-                logger.error(f"[User {user_id}] Failed to update user's last sync time")
-
-            # Schedule another sync if there is not one already running
-            if 'sync_sfn' not in user or user['sync_sfn'] is None:
-                # if this fails, this message should be processed again
-                new_sfn_exec = sfn.start_execution(
-                    stateMachineArn=os.environ['AWS_SFN_ARN'],
-                    input=json.dumps({
-                        'user_id': user_id
-                    })
-                )
-                try:
-                    # Save running execution arn
-                    update_dynamodb_user(
-                        user_id=user_id,
-                        data={
-                            'sync_sfn': new_sfn_exec['executionArn']
-                        }
-                    )
-                except ClientError as e:
-                    logger.error(f"[User {user_id}] Failed to save sync SFN arn but continuing execution.")
+            if msg_contents['type'] == 'AUTO_SYNC':
+                schedule_auto_sync()
+            else:
+                user_id = msg_contents['user_id']
+                sync_user(user_id)
         except Exception as e:
-            logger.error(f"[User {user_id}] Sync process failed: {e}")
+            if msg_contents['type'] == 'AUTO_SYNC':
+                logger.error(f'[AUTO_SYNC] Scheduling auto sync failed: {e}')
+            else:
+                logger.error(f"[User {user_id}] Sync process failed: {e}")
             failures.append({
                 'itemIdentifier': msg['messageId']
             })
@@ -143,3 +47,100 @@ def lambda_handler(event, _):
     return {
         'batchItemFailures': failures
     }
+
+def schedule_auto_sync():
+    """
+    Schedules auto-sync for every user that has it enabled.
+    """
+    dynamodb = boto3.resource(
+        'dynamodb',
+        region_name=os.environ['AWS_REGION_NAME']
+    )
+    user_table = dynamodb.Table(os.environ['AWS_USER_DYNAMODB_TABLE'])
+    sync_users = user_table.scan(
+        Select='SPECIFIC_ATTRIBUTES',
+        ProjectionExpression='id',
+        FilterExpression=Attr('sync_enabled').eq(True)
+    )['Items']
+
+    sns = boto3.resource('sns', region_name=os.environ['AWS_REGION_NAME'])
+    sync_topic = sns.Topic(os.environ['AWS_SNS_SYNC_TOPIC'])
+    # A bit slow if there were hundreds or thousands of users, but I'm not 
+    # planning on having that many users. If I were to scale this up, would
+    # probably do a batch publish.
+    for user in sync_users:
+        sync_topic.publish(Message=json.dumps({ 'user_id': user['id'] }))
+
+    # Reschedule another mass auto-sync.
+    sfn = boto3.client('stepfunctions')
+    # If this fails, this message should be processed again so not catching error
+    sfn.start_execution(
+        stateMachineArn=os.environ['AWS_SFN_ARN'],
+        input=json.dumps({
+            'type': 'AUTO_SYNC'
+        })
+    )
+
+def sync_user(user_id):
+    """
+    Syncs a single user's MAL to their AniList.
+
+    Args:
+        user_id (str): The AniMalSync id of the user to sync
+    """
+    user = get_dynamodb_user(
+        user_id=user_id,
+        fields=[
+            'id', 'anilist_user_id', 'email', 'sent_mal_auth_email',
+            'mal_access_token', 'mal_refresh_token', 'email_verified',
+            'last_sync_timestamp', 'sync_enabled'
+        ]
+    ) 
+
+    # Check that user can be synced
+    if user is None:
+        raise AniMalUserNotFoundException(user_id)
+
+    if not user['email_verified']:
+        raise EmailNotVerifiedException(user_id)
+
+    if 'mal_access_token' not in user or 'mal_refresh_token' not in user:
+        raise MalUnauthorizedException(user_id)
+
+    if not user['sync_enabled']: # Do not run script if user disabled sync
+        return
+
+    media_entries = anilist.fetch_recently_updated_media(
+        user['anilist_user_id'], user.get('last_sync_timestamp', int(time.time()))
+    )[::-1]
+
+    # Iterate through entries and update on MAL
+    for entry in media_entries:
+        try:
+            mal.update_media_list_entry(user, entry)
+            logger.info(f"[User {user['id']}] ({entry['media']['type']}) Synced {AnilistClient.get_media_title(entry)}")
+            log_sync(user, entry, True)
+        except MalUnauthorizedException:
+            # If the user is not authorized on MAL, cease all further updates
+            # and send authorization email
+            try:
+                send_mal_authorization_email(user=user)
+                return
+            except ClientError as e:
+                # If sending authorization email failed, count this message as a failed message
+                logger.error(f"[User {user['id']}] Could not trigger OAuth email lambda: {e}")
+                raise e
+        except HTTPException as e:
+            logger.error(f"[User {user['id']}] ({entry['media']['type']}) Failed to sync {AnilistClient.get_media_title(entry)}")
+            log_sync(user, entry, False)
+
+    try:
+        # Update user's last sync time (assuming no mal authorization was needed)
+        update_dynamodb_user(
+            user_id=user_id,
+            data={
+                'last_sync_timestamp': int(time.time())
+            }
+        )
+    except ClientError as e:
+        logger.error(f"[User {user_id}] Failed to update user's last sync time")

--- a/lambda/sync/sync.py
+++ b/lambda/sync/sync.py
@@ -69,7 +69,10 @@ def schedule_auto_sync():
     # planning on having that many users. If I were to scale this up, would
     # probably do a batch publish.
     for user in sync_users:
-        sync_topic.publish(Message=json.dumps({ 'user_id': user['id'] }))
+        sync_topic.publish(Message=json.dumps({
+            'type': 'USER',
+            'user_id': user['id']
+            }))
 
     # Reschedule another mass auto-sync.
     sfn = boto3.client('stepfunctions')

--- a/web/utils.py
+++ b/web/utils.py
@@ -251,6 +251,7 @@ def perform_sync(*, user_id):
     sns = boto3.resource('sns', region_name=app.config['AWS_REGION_NAME'])
     sync_topic = sns.Topic(app.config['AWS_SNS_SYNC_TOPIC'])
     sync_topic.publish(Message=json.dumps({
+        'type': 'USER',
         'user_id': user_id,
     }))
 

--- a/web/utils.py
+++ b/web/utils.py
@@ -238,32 +238,21 @@ def mal_is_authorized(user):
 
     return resp.ok
             
-def schedule_sync(*, user_id, now=False):
+def perform_sync(*, user_id):
     """
     Schedules a sync for an AniMalSync user.
 
     Args:
         user_id (str): AniMalSync user id
-        now (bool): Whether the sync should happen immediately
 
     Raises:
         (ClientError): Failed to schedule sync
     """
-    if now:
-        sns = boto3.resource('sns', region_name=app.config['AWS_REGION_NAME'])
-        sync_topic = sns.Topic(app.config['AWS_SNS_SYNC_TOPIC'])
-        sync_topic.publish(Message=json.dumps({
-            'user_id': user_id,
-            'force': True
-        }))
-    else:
-        sfn = boto3.client('stepfunctions')
-        sfn.start_execution(
-            stateMachineArn=app.config['AWS_SFN_SYNC'],
-            input=json.dumps({
-                'user_id': user_id
-            })
-        )
+    sns = boto3.resource('sns', region_name=app.config['AWS_REGION_NAME'])
+    sync_topic = sns.Topic(app.config['AWS_SNS_SYNC_TOPIC'])
+    sync_topic.publish(Message=json.dumps({
+        'user_id': user_id,
+    }))
 
 def hash_password(password):
     """

--- a/web/views.py
+++ b/web/views.py
@@ -10,7 +10,7 @@ from auth import User, login_manager, verify_password
 from forms import ChangeAniListUsernameForm, ChangeEmailForm, ChangePasswordForm, ForgotPasswordForm, LoginForm, RegisterForm, ResetPasswordForm
 from utils import (hash_password, redirect_back, get_redirect_target, get_dynamodb_user,
                   update_dynamodb_user, get_anilist_username, mal_is_authorized,
-                  schedule_sync)
+                  perform_sync)
 
 os.environ['TZ'] = "America/New_York"
 time.tzset()
@@ -359,7 +359,7 @@ def authorize_mal():
     # If the user's sync is enabled, send another request for sync.
     if user['sync_enabled']:
         try:
-            schedule_sync(user_id=user_id, now=True)
+            perform_sync(user_id=user_id)
         except ClientError as e:
             app.logger.error(
                 f"[User {user_id}] Failed to start new sync after MAL auth: {e}"
@@ -430,7 +430,7 @@ def autosync():
             }, 401
 
         try:
-            schedule_sync(user_id=current_user.id, now=True)
+            perform_sync(user_id=current_user.id)
         except ClientError as e:
             app.logger.error(f"Failed to schedule sync for user {current_user.id}: {e}")
             return {


### PR DESCRIPTION
Closes #5 

## Fix

Instead of scheduling individual user auto-syncs, the SFN now simply sends an SNS notification for scheduling a mass sync. The sync script, then, when receiving this type of sync, will individually create SNS notifications for each of those users.